### PR TITLE
Fixed urllib import to add support for Python 2.

### DIFF
--- a/wagtailerrorpages/templatetags/wagtailerrorpages_tags.py
+++ b/wagtailerrorpages/templatetags/wagtailerrorpages_tags.py
@@ -1,6 +1,11 @@
 from django import template
 from wagtail.wagtailcore.models import Page
-from urllib.parse import unquote_plus
+try:
+    # Python 3
+    from urllib.parse import unquote_plus
+except ImportError:
+    # Python 2
+    from urllib import unquote_plus
 
 register = template.Library()
 


### PR DESCRIPTION
Due to the standard library changes made in Python 3, the import of `unquote_plus` in the template tags is broken in Python 2. This PR fixes that, which makes wagtailerrorpages fully compatible with Python 2.