### PR TITLE
Show only public pages in search suggestions

### DIFF
--- a/wagtailerrorpages/templatetags/wagtailerrorpages_tags.py
+++ b/wagtailerrorpages/templatetags/wagtailerrorpages_tags.py
@@ -14,7 +14,7 @@ register = template.Library()
 def message404(context):
     url_path = context['request'].path_info
     search_query = unquote_plus(url_path).replace('/', ' ')
-    search_results = Page.objects.live().search(search_query)
+    search_results = Page.objects.live().public().search(search_query)
 
     return {
         'search_query': search_query,


### PR DESCRIPTION
I realise that [the search results are configurable ][0], and that Wagtail is agnostic on this matter, but for wagtailerrorpages it seems sensible for the default behaviour not to be to shepherd casual visitors towards private, password-protected pages.

[0]: https://github.com/alexgleason/wagtailerrorpages#custom-search-behavior