### PR TITLE
Add max_results to message404

### DIFF
--- a/wagtailerrorpages/templatetags/wagtailerrorpages_tags.py
+++ b/wagtailerrorpages/templatetags/wagtailerrorpages_tags.py
@@ -13,10 +13,10 @@ register = template.Library()
 
 
 @register.inclusion_tag('wagtailerrorpages/fragments/404message.html', takes_context=True)
-def message404(context):
+def message404(context, max_results=5):
     url_path = context['request'].path_info
     search_query = unquote_plus(url_path).replace('/', ' ')
-    search_results = Page.objects.live().public().search(search_query)
+    search_results = Page.objects.live().public().search(search_query)[0:max_results]
     search = True
 
     try:


### PR DESCRIPTION
We were having issues where the search would return way too many results and overrun the page.  This just limits it to the first 5, but adds an argument to change it on the template tag.  
If you would like me to handle it a different way, just let me know. 